### PR TITLE
Version bump for RTS smoothing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "kalmanfilt"
-version = "0.2.4"
-authors = ["Jacob Trueb <jtrueb@northwestern.edu", "Michael Mauderer <michael@michaelmauderer.com>"]
+version = "0.2.5"
+authors = [
+    "Jacob Trueb <jtrueb@northwestern.edu",
+    "Michael Mauderer <michael@michaelmauderer.com>",
+]
 edition = "2021"
 repository = "https://github.com/trueb2/kalmanfilt"
 license = "MIT"
@@ -13,7 +16,9 @@ keywords = ["filters", "kalman", "signal-processing"]
 
 [dependencies]
 nalgebra = { version = "0.32.3", default-features = false, features = ["libm"] }
-num-traits = { version = "0.2.17", default-features = false, features = ["libm"]}
+num-traits = { version = "0.2.17", default-features = false, features = [
+    "libm",
+] }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"


### PR DESCRIPTION
Description:
This PR introduces support for Rauch-Tung-Striebel (RTS) smoothing to the Kalman filter implementation. RTS smoothing enhances the performance of the Kalman filter by providing smoother estimates of past states, particularly useful when analyzing systems where future data can help refine past state estimates.

The implementation can be used with the following example:
```rust

let mut kf: KalmanFilter<f64, U2, U1, U1> = KalmanFilter::default();
kf.x = Vector2::new(2.0, 0.0);
kf.F = Matrix2::new(1.0, 1.0, 0.0, 1.0);
kf.H = Vector2::new(1.0, 0.0).transpose();
kf.P *= 1000.0;
kf.R = Matrix1::new(5.0);
kf.Q = Matrix2::repeat(0.0001);

// Kalman filter fowards to collect states and covariances
let mut xs = vec![];
let mut Ps = vec![];
for t in 0..100 {
    let z = Vector1::new(t as f64);
    kf.update(&z, None, None).unwrap();
    kf.predict(None, None, None, None);
    xs.push(kf.x);
    Ps.push(kf.P);
}

// RTS smooth backwards using knowledge of the future to smooth the past
let rts = kf
    .rts_smoother(&xs, &Ps, None, None, RTSSmoothedResults::new())
    .unwrap();
std::dbg!(&rts.x);   // state
std::dbg!(&rts.P);   // covariance
std::dbg!(&rts.K);   // gain
std::dbg!(&rts.Pp);  // predicted covariance

```
Key Features:
* **RTS Smoother**: Implements Rauch-Tung-Striebel smoothing to provide better estimates of historical states using future observations. This is particularly useful in applications where retrospective accuracy is critical.
* **Compatibility**: The RTS smoother integrates with the existing Kalman filter and state estimation workflow.
* **Reusable Results**: After applying the RTS smoother, the smoother outputs corrected estimates (rts.x), corrected covariances (rts.P), smoother gain (rts.K), and prior corrected covariances (rts.Pp), allowing users to refine state estimates and their uncertainties retrospectively. The results may be reused to prevent further allocations. 

`nalgebra` does not support 3D matrices, so we have Vecs of OMatrix holding the RTS batched results.

Example Use Case:
In the provided example, a Kalman filter is used to estimate the position of a system over time. After running the filter, the rts_smoother is called to refine the estimates using the filter's results (xs and Ps). The resulting smoothed estimates match equivalent results from the filterpy Python library, demonstrating the correctness of the implementation.
This feature is designed to improve historical data estimation and is highly relevant for applications such as signal processing, sensor fusion, and control systems where past data refinement can lead to more accurate interpretations of system behavior.





